### PR TITLE
Fix unclosed file

### DIFF
--- a/recipes-kernel/linux/linux-chip_git.bb
+++ b/recipes-kernel/linux/linux-chip_git.bb
@@ -69,4 +69,6 @@ python () {
     if 'CONFIG_KERNEL_LZO=y\n' in configfile.readlines():
         depends = d.getVar('DEPENDS', False)
         d.setVar('DEPENDS', depends + ' lzop-native')
+
+    configfile.close()
 }


### PR DESCRIPTION
WARNING: /projects/meta-chip/recipes-kernel/linux/linux-chip_git.bb: <string>:14: ResourceWarning: unclosed file <_io.TextIOWrapper name='/projects/meta-chip/recipes-kernel/linux/linux-chip/defconfig' mode='r' encoding='UTF-8'>