### PR TITLE
Fix build on OE master

### DIFF
--- a/recipes-bsp/u-boot/u-boot-chip_git.bb
+++ b/recipes-bsp/u-boot/u-boot-chip_git.bb
@@ -2,6 +2,7 @@ require recipes-bsp/u-boot/u-boot.inc
 
 DESCRIPTION = "U-Boot port for C.H.I.P. boards"
 
+LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=0507cd7da8e7ad6d6701926ec9b84c95"
 
 DEPENDS += "dtc-native"


### PR DESCRIPTION
ERROR: /projects/meta-chip/recipes-bsp/u-boot/u-boot-chip_git.bb: This recipe does not have the LICENSE field set (u-boot-chip)
ERROR: Failed to parse recipe: /data/projects/rpi-a2dp-sink/meta-chip/recipes-bsp/u-boot/u-boot-chip_git.bb