### PR TITLE
rtl8723bs: update to latest git

### DIFF
--- a/recipes-kernel/rtl8723bs/rtl8723bs_git.bb
+++ b/recipes-kernel/rtl8723bs/rtl8723bs_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://core/rtw_ap.c;beginline=3;endline=12;md5=6590b50a1b18
 
 inherit module
 
-SRCREV = "11ab92d8ccd71c80f0102828366b14ef6b676fb2"
+SRCREV = "db2c4f61d48fe3b47c167c8bcd722ce83c24aca5"
 SRC_URI = "git://github.com/hadess/rtl8723bs.git;protocol=https \
            file://0001-rtl8723bs-add-modules_install-and-correct-depmod.patch \
           "


### PR DESCRIPTION
Where 'latest' is before the repo was disabled due to the driver being
merged into mainline/staging. Post 4.10 we can drop this recipe, but
since we're using 4.3.vendor...

Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>