### PR TITLE
chip-u-boot-scr: Bump the limit to fit a resin image.

### DIFF
--- a/recipes-bsp/chip-u-boot-scr/chip-u-boot-scr.bb
+++ b/recipes-bsp/chip-u-boot-scr/chip-u-boot-scr.bb
@@ -19,7 +19,8 @@ UBI_MEMIMG_ADDR = "0x4b000000"
 UBI_FLASH_ADDR = "0x1000000"
 OOB_SIZE = "1664"
 SCRIPTADDR = "0x43100000"
-UBI_SIZE="0x0A000000"
+# max supported image size
+UBI_SIZE ?= "0x0F000000"
 
 do_compile[depends] += "u-boot-chip:do_deploy"
 do_compile() {


### PR DESCRIPTION
We may need to bump this again in the future. Currently the image size is 0xD59F800 bytes, so bump the limit from 0xA000000 to 0xF000000