### PR TITLE
rtl8723bs: drop firmware

### DIFF
--- a/recipes-kernel/rtl8723bs/rtl8723bs_git.bb
+++ b/recipes-kernel/rtl8723bs/rtl8723bs_git.bb
@@ -18,12 +18,5 @@ EXTRA_OEMAKE = "KSRC=${STAGING_KERNEL_DIR} \
                 ARCH=${ARCH} \
                 MODDESTDIR=${D}/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/ \
                "
-
-do_install_append() {
-	install -d ${D}/lib/firmware/rtlwifi
-        install -m0644 ${S}/*.bin ${D}/lib/firmware/rtlwifi
-}
-
 PKGV = "${KERNEL_VERSION}"
 
-FILES_${PN} += "/lib/firmware"


### PR DESCRIPTION
The firmware is in linux-firmware nowadays, leading to errors like this:

Collected errors:
 * check_data_file_clashes: Package rtl8723bs wants to install file /build/angstrom/v2017.12/build/tmp-angstrom-glibc/work/chip-angstrom-linux-gnueabi/domoticz-image/1.0-r0/rootfs/lib/firmware/rtlwifi/rtl8723bs_ap_wowlan.bin
        But that file is already provided by package  * linux-firmware-rtl8723
 * check_data_file_clashes: Package rtl8723bs wants to install file /build/angstrom/v2017.12/build/tmp-angstrom-glibc/work/chip-angstrom-linux-gnueabi/domoticz-image/1.0-r0/rootfs/lib/firmware/rtlwifi/rtl8723bs_bt.bin
        But that file is already provided by package  * linux-firmware-rtl8723
 * check_data_file_clashes: Package rtl8723bs wants to install file /build/angstrom/v2017.12/build/tmp-angstrom-glibc/work/chip-angstrom-linux-gnueabi/domoticz-image/1.0-r0/rootfs/lib/firmware/rtlwifi/rtl8723bs_wowlan.bin
        But that file is already provided by package  * linux-firmware-rtl8723
 * check_data_file_clashes: Package rtl8723bs wants to install file /build/angstrom/v2017.12/build/tmp-angstrom-glibc/work/chip-angstrom-linux-gnueabi/domoticz-image/1.0-r0/rootfs/lib/firmware/rtlwifi/rtl8723bs_nic.bin
        But that file is already provided by package  * linux-firmware-rtl8723

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
